### PR TITLE
fix: Use the postgresml bb8 fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,8 +170,7 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 [[package]]
 name = "bb8"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b4b0f25f18bcdc3ac72bdb486ed0acf7e185221fd4dc985bc15db5800b0ba2"
+source = "git+https://github.com/postgresml/bb8?rev=6971f9565dac43de9f608a9d9379c19507f56c00#6971f9565dac43de9f608a9d9379c19507f56c00"
 dependencies = [
  "async-trait",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
 md-5 = "0.10"
-bb8 = "0.8.1"
+bb8 = { git = "https://github.com/postgresml/bb8", rev = "6971f9565dac43de9f608a9d9379c19507f56c00" }
 async-trait = "0.1"
 rand = "0.8"
 chrono = "0.4"
@@ -51,4 +51,3 @@ tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter", "st
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"
-


### PR DESCRIPTION
Use the postgresml bb8 fork while waiting on https://github.com/djc/bb8/pull/164 to ship.

This may fix potential deadlocks in pgcat when returning a server connection to the bb8 inner pool upon transaction completion.

We've seen a single pgcat pod keeping server connections active for longer than expected across multiple pools. At the same time, the upstream postgres servers didn't show matching active connections suggesting that this pgcat pod was failing to return server connections to their pools when transitioning them from active to idle. Hence leading to the increased client wait time across our shards we experienced as fewer server connections were available.

