### PR TITLE
Update bb8 to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,8 +169,9 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bb8"
-version = "0.8.1"
-source = "git+https://github.com/postgresml/bb8?rev=6971f9565dac43de9f608a9d9379c19507f56c00#6971f9565dac43de9f608a9d9379c19507f56c00"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7c2093d15d6a1d33b1f972e1c5ea3177748742b97a5f392aa83a65262c6780"
 dependencies = [
  "async-trait",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
 md-5 = "0.10"
-bb8 = { git = "https://github.com/postgresml/bb8", rev = "6971f9565dac43de9f608a9d9379c19507f56c00" }
+bb8 = "0.8.3"
 async-trait = "0.1"
 rand = "0.8"
 chrono = "0.4"


### PR DESCRIPTION
To get https://github.com/djc/bb8/pull/186 and https://github.com/djc/bb8/pull/189.

Let's see how this behaves and if we're not seeing issues, we can open a PR against upstream pgcat.