### PR TITLE
Add load balancing aware query cancellation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -759,7 +759,7 @@ where
 
         trace!("Startup OK");
         let stats = Arc::new(ClientStats::new(
-            process_id,
+            secret_key,
             application_name,
             username,
             pool_name,

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,14 +17,14 @@ use crate::auth_passthrough::refetch_auth_hash;
 use crate::config::{
     get_config, get_idle_client_in_transaction_timeout, Address, AuthType, PoolMode,
 };
-use crate::constants::*;
-use crate::messages::*;
 use crate::plugins::PluginOutput;
 use crate::pool::{get_pool, ClientServerMap, ConnectionPool};
 use crate::query_router::{Command, QueryRouter};
 use crate::server::{Server, ServerParameters};
 use crate::stats::{ClientStats, ServerStats};
 use crate::tls::Tls;
+use crate::{constants::*, i32_to_ipv4, PGCAT_IP};
+use crate::{ipv4_to_i32, messages::*};
 
 use tokio_rustls::server::TlsStream;
 
@@ -480,7 +480,12 @@ where
         }
 
         // Generate random backend ID and secret key
-        let process_id: i32 = rand::random();
+        let process_id = match *PGCAT_IP {
+            // Override the process ID with the pgcat IP so that cancelation queries can be
+            // forwarded back to this pgcat instance if they end up being received on another pgcat instance.
+            Some(pgcat_ip) => ipv4_to_i32(pgcat_ip),
+            None => rand::random(),
+        };
         let secret_key: i32 = rand::random();
 
         let mut prepared_statements_enabled = false;
@@ -831,6 +836,23 @@ where
         // The client wants to cancel a query it has issued previously.
         if self.cancel_mode {
             trace!("Sending CancelRequest");
+
+            if let Some(pgcat_ip) = *PGCAT_IP {
+                let destination_ip = i32_to_ipv4(self.process_id);
+                if destination_ip != pgcat_ip {
+                    // This cancel query is not meant for us. Forward it to the correct pgcat instance.
+                    // This assumes that all pgcat nodes are listening on the same port.
+                    let port = get_config().general.port;
+                    info!("Forwarding cancel request to {}:{}", destination_ip, port);
+                    return Server::cancel(
+                        &destination_ip.to_string(),
+                        port,
+                        self.process_id,
+                        self.secret_key,
+                    )
+                    .await;
+                }
+            }
 
             let (process_id, secret_key, address, port) = {
                 let guard = self.client_server_map.lock();

--- a/src/client.rs
+++ b/src/client.rs
@@ -845,7 +845,10 @@ where
 
                     // The client doesn't know / got the wrong server,
                     // we're closing the connection for security reasons.
-                    None => return Ok(()),
+                    None => {
+                        error!("An unknown cancel query was received and ignored. Was it sent to the wrong server?");
+                        return Ok(());
+                    }
                 }
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+use std::{env, net::Ipv4Addr};
+
+use once_cell::sync::Lazy;
+
 pub mod admin;
 pub mod auth_passthrough;
 pub mod client;
@@ -19,6 +23,23 @@ pub mod sharding;
 pub mod stats;
 pub mod tls;
 
+/// Store current pgcat IP if PGCAT_IP environment variable is set.
+pub static PGCAT_IP: Lazy<Option<Ipv4Addr>> = Lazy::new(|| {
+    env::var("PGCAT_IP")
+        .ok()
+        .and_then(|ip_str| ip_str.parse().ok())
+});
+
+fn ipv4_to_i32(ip: Ipv4Addr) -> i32 {
+    let octets = ip.octets();
+    i32::from_be_bytes(octets)
+}
+
+fn i32_to_ipv4(n: i32) -> Ipv4Addr {
+    let octets = n.to_be_bytes();
+    Ipv4Addr::from(octets)
+}
+
 /// Format chrono::Duration to be more human-friendly.
 ///
 /// # Arguments
@@ -39,4 +60,17 @@ pub fn format_duration(duration: &chrono::Duration) -> String {
         "{}d {}:{}:{}.{}",
         days, hours, minutes, seconds, milliseconds
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ipv4_i32_conversion() {
+        let ip = Ipv4Addr::new(192, 168, 1, 1);
+        let n = ipv4_to_i32(ip);
+        let ip_converted = i32_to_ipv4(n);
+        assert_eq!(ip, ip_converted);
+    }
 }


### PR DESCRIPTION
If PGCAT_IP environment variable is set, it is used to override the random process_id sent back to clients for the purpose of query cancellation.

This allows pgcat instances to detect query cancellations that are not meant for them and forward them to the right pgcat instance (via IP address)

By using a process_id that is the same for each pgcat instance, we increase the risk of collision for the secret_key used for query cancellation.

We would need to have 2 client connections using the same pgcat instance and same secret key, both active at the same time and one of them triggering a cancellation to risk the wrong query being cancelled.

Given that we use pgcat to limit the number of active connections against postgres servers, this risk of collision is still extremely low.

---
This is slightly different to what pgbouncer does. pgbouncer only overrides a few bits of the process_id to insert a much smaller key that is mapped to other pgbouncer nodes that are declared in the configuration. Given the way we run pgcat on k8s, it's not easy for us to do something similar deterministically. Using the full IP address sidestep the need to maintain a list of pgcat peers up to date.