### PR TITLE
Add docs about #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,20 @@ The config can be reloaded by sending a `kill -s SIGHUP` to the process or by qu
 
 Mirroring allows to route queries to multiple databases at the same time. This is useful for prewarning replicas before placing them into the active configuration, or for testing different versions of Postgres with live traffic.
 
+### Load balancing aware query cancellation
+
+If multiple pgcat instances are running behind a load balancer,
+query cancellation requests may be routed to the wrong pgcat instance
+by the load balancer and silently dropped.
+
+To address this, pgcat supports including its own IP address
+in the cancellation request secret. This is enabled by setting
+`PGCAT_IP` environment variable to the IP address of the pgcat instance.
+
+A pgcat pod with `PGCAT_IP` set will only accept cancellation requests
+that include its own IP address in the secret. Otherwise, it will forward the cancellation
+request to the IP address included in the secret.
+
 ## License
 
 PgCat is free and open source, released under the MIT license.

--- a/src/client.rs
+++ b/src/client.rs
@@ -868,7 +868,7 @@ where
                     // The client doesn't know / got the wrong server,
                     // we're closing the connection for security reasons.
                     None => {
-                        error!("An unknown cancel query was received and ignored. Was it sent to the wrong server?");
+                        info!("An unknown cancel query was received and ignored. Was it sent to the wrong server?");
                         return Ok(());
                     }
                 }


### PR DESCRIPTION
Add some docs about #6.

Also downgrade the log printed when a query cancellation request is dropped. We are seeing this quite a bit in our environment which I suspect is because cancellation requests are received after the query is finished and its connection released back to the pool. In that case, there's nothing to do.