### PR TITLE
fix #6: Do not forward cancellation requests to ourselves.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -839,7 +839,10 @@ where
 
             if let Some(pgcat_ip) = *PGCAT_IP {
                 let destination_ip = i32_to_ipv4(self.process_id);
-                if destination_ip != pgcat_ip {
+                if !destination_ip.is_unspecified()
+                    && !destination_ip.is_loopback()
+                    && destination_ip != pgcat_ip
+                {
                     // This cancel query is not meant for us. Forward it to the correct pgcat instance.
                     // This assumes that all pgcat nodes are listening on the same port.
                     let port = get_config().general.port;


### PR DESCRIPTION
If we ever receive a cancellation request that maps to an IP that is 0.0.0.0 or 127.0.0.1 (and similar), we do NOT want to forward it as it leads to an infinte forward loop and ephemeral port exhaustion.

Fixup #6.