### PR TITLE
chore: add Backstage catalog and TechDocs scaffolding

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pgcat
+  description: PostgreSQL pooler and proxy with support for sharding, load balancing, failover, and mirroring
+  annotations:
+    github.com/project-slug: 'OneSignal/pgcat'
+    circleci.com/project-slug: 'github/OneSignal/pgcat'
+    backstage.io/techdocs-ref: 'dir:.'
+  tags:
+    - lang-rust
+spec:
+  type: service
+  lifecycle: production
+  owner: eng-platform

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: pgcat
+
+plugins:
+  - techdocs-core
+
+nav:
+  - Home: index.md


### PR DESCRIPTION
## Summary

- Creates `catalog-info.yaml` registering pgcat in the Backstage service catalog under `eng-platform`
- Adds `mkdocs.yml` with `techdocs-core` plugin to enable TechDocs
- Adds `docs/index.md` symlinked to `README.md`

pgcat is a PostgreSQL pooler and proxy (like PgBouncer) with support for sharding, load balancing, failover, and mirroring.

## Changes

- `catalog-info.yaml`: new file — Component kind, owner `eng-platform`, lifecycle `production`, `techdocs-ref` annotation
- `mkdocs.yml`: new file with `techdocs-core` plugin
- `docs/index.md`: symlink to `../README.md`

## Test plan

- [ ] Verify `pgcat` appears in the Backstage catalog under `eng-platform`
- [ ] Verify TechDocs tab renders for `pgcat`
- [ ] Confirm docs render from README